### PR TITLE
[add]vite.configファイルにaliasの設定を追加

### DIFF
--- a/dev/vite/src/pages/Home.tsx
+++ b/dev/vite/src/pages/Home.tsx
@@ -2,10 +2,10 @@ import { useState } from "react";
 
 // local imports
 
+import mainBackground from "@/assets/Home/mainBackground.png";
+import reactLogo from "@/assets/react.svg";
 // images
 import viteLogo from "/vite.svg";
-import mainBackground from "../assets/Home/mainBackground.png";
-import reactLogo from "../assets/react.svg";
 
 const Home = () => {
 	const [count, setCount] = useState<number>(0);

--- a/dev/vite/vite.config.ts
+++ b/dev/vite/vite.config.ts
@@ -1,7 +1,14 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react-swc'
+import { URL, fileURLToPath } from "node:url";
+
+import react from "@vitejs/plugin-react-swc";
+import { defineConfig } from "vite";
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
-})
+	plugins: [react()],
+	resolve: {
+		alias: {
+			"@": fileURLToPath(new URL("./src", import.meta.url)),
+		},
+	},
+});


### PR DESCRIPTION
# 概要・目的

vite.configにaliasの設定を追加した。
この設定により、コンポーネントをimportする際にsrc基準でパスを記述できるようになる。
それにより、import時のパスが見やすくなる。

<!-- レビュアーが理解できるよう、このプルリクの概要と共に、どうしておこなったかの背景が以下に書かれているとグッド -->
