### PR TITLE
fixed menu button.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/css/base.css
+++ b/css/base.css
@@ -5,7 +5,7 @@
     --main-text: #333;
     --main-bg: #fff;
 
-    --btn-bg: #e0e0e0;
+    --btn-bg: #f3f3f3;
     --menu-bg: #f3f3f3;
 }
 
@@ -14,7 +14,7 @@
         --main-text: #ddd;
         --main-bg: #000;
         
-        --btn-bg: #4e4e4e;
+        --btn-bg: #222222;
         --menu-bg: #222222;
     }
 }

--- a/css/menu.css
+++ b/css/menu.css
@@ -16,7 +16,7 @@
     z-index: 3;
     /*丸の形*/
     width: 100%;
-    height: 100px;
+    height: 0px;
     border-radius: 0%;
     background: var(--menu-bg);
     /*丸のスタート位置と形状*/
@@ -29,8 +29,8 @@
 }
 
 .circle-bg.circleactive {
-    transform: scale(50);
     /*クラスが付与されたらscaleを拡大*/
+    height: 100%;
 }
 
 
@@ -129,11 +129,11 @@
 
 .openbtn1 {
     background-color: var(--btn-bg);
-    filter: drop-shadow(0px 0px 4px rgba(0, 0, 0, 0.7));
-    border-radius: 90% 0% 0% 0%;
+    filter: drop-shadow(0px 0px 4px rgba(0, 0, 0, 0.4));
+    border-radius: 50% 50% 50% 50%;
     position: fixed;
-    bottom: 0px;
-    right: 0px;
+    bottom: 7px;
+    right: 7px;
     z-index: 9999;
 
     /*ボタンを最前面に*/
@@ -142,6 +142,9 @@
     height: 75px;
 }
 
+.openbtn1.openbtn1.active {
+    filter: drop-shadow(0px 0px 4px rgba(0, 0, 0, 0));
+}
 
 /*×に変化*/
 
@@ -149,7 +152,7 @@
     display: inline-block;
     transition: all .4s;
     position: absolute;
-    left: 28px;
+    left: 20px;
     height: 3px;
     border-radius: 2px;
     background-color: var(--main-text);
@@ -157,20 +160,20 @@
 }
 
 .openbtn1 span:nth-of-type(1) {
-    bottom: 20px;
+    bottom: 27px;
 }
 
 .openbtn1 span:nth-of-type(2) {
-    bottom: 29px;
+    bottom: 36px;
 }
 
 .openbtn1 span:nth-of-type(3) {
-    bottom: 38px;
+    bottom: 45px;
 }
 
 .openbtn1.active span:nth-of-type(1) {
-    bottom: 33px;
-    left: 33px;
+    bottom: 40px;
+    left: 26px;
     transform: translateY(6px) rotate(-45deg);
     width: 30%;
 }
@@ -180,8 +183,8 @@
 }
 
 .openbtn1.active span:nth-of-type(3) {
-    bottom: 22px;
-    left: 33px;
+    bottom: 29px;
+    left: 26px;
     transform: translateY(-6px) rotate(45deg);
     width: 30%;
 }

--- a/dev/vite/src/components/button/Button.stories.ts
+++ b/dev/vite/src/components/button/Button.stories.ts
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import { Button } from './Button';
+
+// Metaの型定義を明示的に記述
+const meta = {
+  title: 'Button',
+  component: Button,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    backgroundColor: { control: 'color' },
+    color: { control: 'color' },
+    primary: { control: 'boolean' },
+    size: {
+      control: { type: 'select' },
+      options: ['small', 'medium', 'large'],
+    },
+  },
+  args: { onClick: fn() },
+} satisfies Meta<typeof Button>;
+
+export default meta;
+
+// Storyの型定義をMetaから導出
+type Story = StoryObj<typeof meta>;
+
+// More on writing stories with args: https://storybook.js.org/docs/writing-stories/args
+export const Primary: Story = {
+  args: {
+    primary: true,
+    label: 'Button',
+  },
+};
+
+export const Secondary: Story = {
+  args: {
+    label: 'Button',
+  },
+};
+
+export const Large: Story = {
+  args: {
+    size: 'large',
+    label: 'Button',
+  },
+};
+
+export const Small: Story = {
+  args: {
+    size: 'small',
+    label: 'Button',
+  },
+};
+
+export const Test: Story = {
+  args: {
+    primary: false,
+    label: "Button"
+  }
+};

--- a/dev/vite/src/components/button/Button.tsx
+++ b/dev/vite/src/components/button/Button.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+
+// css
+import './Button.css'
+
+export interface ButtonProps {
+    /** ボタンが重要なアクションを示すかどうか */
+    primary?: boolean;
+    /** ボタンのラベル */
+    label: string;
+    /** 背景色 */
+    backgroundColor?: string;
+    /** テキストの色 */
+    color?: string;
+    /** ボタンの幅 */
+    width?: number;
+    /** ボタンの高さ */
+    height?: number;
+    /** ボタンのアール */
+    borderRadius?: number;
+    /** クリック時のハンドラ */
+    onClick?: () => void;
+}
+
+export const Button: React.FC<ButtonProps> = ({
+    primary = false,
+    label,
+    backgroundColor,
+    color,
+    width,
+    height,
+    borderRadius,
+    ...props
+}: ButtonProps) => {
+    const mode = primary ? 'storybook-button--primary' : 'storybook-button--secondary';
+    return (
+        <button
+            type="button"
+            className={['storybook-button', mode].join(' ')}
+            style={{ backgroundColor, color, width, height, borderRadius }}
+            {...props}
+        >
+            {label}
+        </button>
+    );
+}

--- a/index.html
+++ b/index.html
@@ -65,13 +65,13 @@
             </div>
 
             <!-- グローバルメニュー -->
-            <div class="NEWS">
+            <!-- <div class="NEWS">
                 <p class="ledText importMainFont">
                     <span>ここにnewsが表示されます！　　　　　　　　　　　　　　　　　　　　　電光掲示板みたいでいいですよね!　　　　　　　　　　　　　　　　　　　　　　　<a
                             href="./news.html#links01">[3/5]サイトを試験的に公開しました。</a>　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　
                         　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　</span>
                 </p>
-            </div>
+            </div> -->
 
             <div class="openbtn1"><span></span><span></span><span></span></div>
             <nav id="g-nav">


### PR DESCRIPTION
# 概要・目的

このプルリクエストでは、新しい再利用可能な `Button` コンポーネントを追加し、Storybook ストーリーを実装しました。また、メニューボタンや関連する CSS のビジュアル改善を行いました。これにより、開発者体験（コンポーネントライブラリの整備）と UI/UX の両方を向上させています。

# 細かな変更点

- `base.css`
  - メニューやボタンのカラーバリエーションを調整（ライト／ダークテーマで統一感を向上）
- `menu.css`
  - `.openbtn1`（メニューボタン）のデザイン改善
    - 完全な円形化
    - ドロップシャドウを柔らかく調整
    - 固定位置を調整
    - ハンバーガー／クローズアイコンの整列を修正
  - `.circle-bg` の高さを変更し、スケール変形を削除 → メニュー表示をより滑らかに
- `index.html`
  - ニュースティッカー部分を一時的にコメントアウト（将来的な修正／不要要素の整理目的）

# 影響範囲・懸念点
- 既存のメニューボタンに依存している部分への影響がないか要確認

# おこなった動作確認
* [x] メニュー開閉動作が Safari / Chrome / Firefox で問題なく動作することを確認
* [x] ダーク／ライトテーマで色の一貫性を確認

# テスト手順
live serverで `index.html` を確認。

# その他
- 特になし。